### PR TITLE
IIM - Optional Download ( alternative to copy )

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,10 @@ env:
     - ANSIBLE_GALAXY_SERVER_IBM_URL=https://galaxy.ansible.com/
     # ANSIBLE_GALAXY_SERVER_IBM_TOKEN is set using secure environment variables
   matrix:
-    - SCENARIO=websphere-v90-centos-8
-    - SCENARIO=websphere-v85-centos-7
-    - SCENARIO=db2111
-    - SCENARIO=db2115
-    - SCENARIO=iim-191-centos-8
+    # - SCENARIO=websphere-v90-centos-8
+    # - SCENARIO=websphere-v85-centos-7
+    # - SCENARIO=db2111
+    # - SCENARIO=db2115
     - SCENARIO=iim-191-centos-8
     - SCENARIO=ihs-v90-centos-8
     - SCENARIO=ihs-v80-centos-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,13 @@ env:
     - ANSIBLE_GALAXY_SERVER_IBM_URL=https://galaxy.ansible.com/
     # ANSIBLE_GALAXY_SERVER_IBM_TOKEN is set using secure environment variables
   matrix:
-    # - SCENARIO=websphere-v90-centos-8
-    # - SCENARIO=websphere-v85-centos-7
-    # - SCENARIO=db2111
-    # - SCENARIO=db2115
+    - SCENARIO=websphere-v90-centos-8
+    - SCENARIO=websphere-v85-centos-7
+    - SCENARIO=db2111
+    - SCENARIO=db2115
     - SCENARIO=iim-191-centos-8
-    # - SCENARIO=ihs-v90-centos-8
-    # - SCENARIO=ihs-v80-centos-7
+    - SCENARIO=ihs-v90-centos-8
+    - SCENARIO=ihs-v80-centos-7
 stage: Molecule Tests
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ env:
     # - SCENARIO=db2111
     # - SCENARIO=db2115
     - SCENARIO=iim-191-centos-8
-    - SCENARIO=ihs-v90-centos-8
-    - SCENARIO=ihs-v80-centos-7
+    # - SCENARIO=ihs-v90-centos-8
+    # - SCENARIO=ihs-v80-centos-7
 stage: Molecule Tests
 
 before_script:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: ibm
 name: spm_middleware
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.6
+version: 1.0.8
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/__ihs-v85/converge.yml
+++ b/molecule/__ihs-v85/converge.yml
@@ -7,6 +7,9 @@
 
   vars:
     ihs_version: 8.5.5.17
+    download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
+    download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
+    
   roles:
     - iim
     - ihs

--- a/molecule/__ihs-v85/converge.yml
+++ b/molecule/__ihs-v85/converge.yml
@@ -9,7 +9,7 @@
     ihs_version: 8.5.5.17
     download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
-    
+
   roles:
     - iim
     - ihs

--- a/molecule/__ihs-v90/converge.yml
+++ b/molecule/__ihs-v90/converge.yml
@@ -7,6 +7,8 @@
 
   vars:
     ihs_version: 9.0.5.8
+    download_url: "{{ lookup('env', 'ARTIFACTORY_URL') }}/{{ lookup('env', 'ARTIFACTORY_REPO') }}/SoftwareInstallers"
+    download_header: { 'X-JFrog-Art-Api': "{{ lookup('env', 'ARTIFACTORY_TOKEN') }}"}
 
   roles:
     - iim

--- a/molecule/iim-191-centos-8/converge.yml
+++ b/molecule/iim-191-centos-8/converge.yml
@@ -10,7 +10,7 @@
 
   vars:
     iim_agent_version: 1.9.1001.20191112_1525
-    download_url: "{{ lookup('env','ARTIFACTORY_URL')}}/{{ lookup('env,'ARTIFACTORY_REPO') }}/SoftwareInstallers"
-    download_header: {'X-JFrog-art-Api': "{{lookup('env','ARTIFACTORY_TOKEN')}}"}
+    download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
+    download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}
     ansible_os_family: redhat
     iim_installer_path: /IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip

--- a/molecule/iim-191-centos-8/converge.yml
+++ b/molecule/iim-191-centos-8/converge.yml
@@ -9,7 +9,8 @@
     - iim
 
   vars:
-    iim_agent_version: 1.9.1001.20191112_1525 
+    iim_agent_version: 1.9.1001.20191112_1525
     download_url: "{{ lookup('env','ARTIFACTORY_URL')}}/{{ lookup('env,'ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: {'X-JFrog-art-Api': "{{lookup('env','ARTIFACTORY_TOKEN')}}"}
     ansible_os_family: redhat
+    iim_installer_path: /IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip

--- a/molecule/iim-191-centos-8/converge.yml
+++ b/molecule/iim-191-centos-8/converge.yml
@@ -9,4 +9,7 @@
     - iim
 
   vars:
-    iim_agent_version: 1.9.1001.20191112_1525
+    iim_agent_version: 1.9.1001.20191112_1525 
+    download_url: "{{ lookup('env','ARTIFACTORY_URL')}}/{{ lookup('env,'ARTIFACTORY_REPO') }}/SoftwareInstallers"
+    download_header: {'X-JFrog-art-Api': "{{lookup('env','ARTIFACTORY_TOKEN')}}"}
+    ansible_os_family: redhat

--- a/molecule/iim-191-centos-8/converge.yml
+++ b/molecule/iim-191-centos-8/converge.yml
@@ -12,5 +12,3 @@
     iim_agent_version: 1.9.1001.20191112_1525
     download_url: "{{ lookup('env','ARTIFACTORY_URL') }}/{{ lookup('env','ARTIFACTORY_REPO') }}/SoftwareInstallers"
     download_header: {'X-JFrog-Art-Api': "{{ lookup('env','ARTIFACTORY_TOKEN' )}}"}
-    ansible_os_family: redhat
-    iim_installer_path: /IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip

--- a/molecule/iim-191-centos-8/molecule.yml
+++ b/molecule/iim-191-centos-8/molecule.yml
@@ -6,7 +6,7 @@ driver:
 
 lint: |
   set -e
-  # yamllint .
+  yamllint .
 
 platforms:
   - name: centos-8

--- a/molecule/iim-191-centos-8/molecule.yml
+++ b/molecule/iim-191-centos-8/molecule.yml
@@ -6,7 +6,7 @@ driver:
 
 lint: |
   set -e
-  yamllint .
+  # yamllint .
 
 platforms:
   - name: centos-8

--- a/roles/iim/README.md
+++ b/roles/iim/README.md
@@ -12,6 +12,9 @@ None
 | ------------------- | ----------------------------------------------------- |
 | `iim_agent_version` | `1.9.1001.20191112_1525`                              |
 | `iim_install_path`  | `/opt/IBM/InstallationManager`                        |
+| `download_url`            | # set this if license and installer is being downloaded from a http server|
+| `download_header`         | # Use this in conjunction with `download_url`   |
+| ------------------------- | ------------------------------------------------|
 
 ## Dependencies
 

--- a/roles/iim/README.md
+++ b/roles/iim/README.md
@@ -12,9 +12,12 @@ None
 | ------------------- | ----------------------------------------------------- |
 | `iim_agent_version` | `1.9.1001.20191112_1525`                              |
 | `iim_install_path`  | `/opt/IBM/InstallationManager`                        |
-| `download_url`            | # set this if license and installer is being downloaded from a http server|
-| `download_header`         | # Use this in conjunction with `download_url`   |
-| ------------------------- | ------------------------------------------------|
+| `download_url`      | # Set this if license and installer is being downloaded from a http server|
+| `download_header`   | # Use this in conjunction with `download_url` |
+| `iim_installer_path`| # Set this to your downloaded installers filepath if copying from local|
+|                       # Set to remote filepath if downloading installers    |
+|                       # Default `/tmp/iim/`                                 |
+| ------------------- | ------------------------------------------------------|
 
 ## Dependencies
 

--- a/roles/iim/defaults/main.yml
+++ b/roles/iim/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 iim_agent_version: 1.9.1001.20191112_1525
 iim_installer_path: /tmp/iim/
-download_url: 
-download_header:
-
+# Server info for downloading installers / repos directly, leave blank to copy
+download_url:  # e.g. https://artifactory/repo
+download_header: # e.g. X-JFrog-Art-Api: "{{ lookup('env', 'MYTOKEN') }}"

--- a/roles/iim/defaults/main.yml
+++ b/roles/iim/defaults/main.yml
@@ -2,4 +2,4 @@
 iim_agent_version: 1.9.1001.20191112_1525
 # Server info for downloading installers / repos directly, leave blank to copy
 download_url:  # e.g. https://artifactory/repo
-download_header: # e.g. X-JFrog-Art-Api: "{{ lookup('env', 'MYTOKEN') }}"
+download_header:  # e.g. X-JFrog-Art-Api: "{{ lookup('env', 'MYTOKEN') }}"

--- a/roles/iim/defaults/main.yml
+++ b/roles/iim/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 iim_agent_version: 1.9.1001.20191112_1525
 iim_installer_path: /tmp/iim/
+download_url: 
+download_header:
+

--- a/roles/iim/defaults/main.yml
+++ b/roles/iim/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 iim_agent_version: 1.9.1001.20191112_1525
-iim_installer_path: /tmp/iim/
 # Server info for downloading installers / repos directly, leave blank to copy
 download_url:  # e.g. https://artifactory/repo
 download_header: # e.g. X-JFrog-Art-Api: "{{ lookup('env', 'MYTOKEN') }}"

--- a/roles/iim/tasks/darwin.yml
+++ b/roles/iim/tasks/darwin.yml
@@ -10,7 +10,16 @@
 - name: Copy installer
   copy:
     src: "{{ iim_installer_path }}"
-    dest: "{{tmp_dir.path}}/iim_installer.tar.gz"
+    dest: "{{ tmp_dir.path }}/"
+  when: download_url is not defined
+  register: iim_zip
+
+- name: Download installer
+  get_url:
+    url: "{{ download_url }}/{{ iim_installer_path }}"
+    dest: "{{ tmp_dir.path }}/"
+    headers: "{{ download_header }}"
+  when: download_url is defined
   register: iim_zip
 
 - name: Extract IIM installer

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -20,9 +20,8 @@
     # url: "{{ artifactory_url }}/{{ artifactory_repo }}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
     url: "{{ download_url }}/{{ iim_installer_path }}"
     mode: '644'
-    headers:
+    headers: "{{ download_header }}"
       # X-JFrog-Art-Api: "{{ artifactory_token }}"
-      {{ download_header }}
   register: iim_zip
   when: download_url is defined
 

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -17,23 +17,11 @@
 - name: Download IIM installer
   get_url:
     dest: "{{ tmp_dir.path }}/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
-    # url: "{{ artifactory_url }}/{{ artifactory_repo }}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
     url: "{{ download_url }}/{{ iim_installer_path }}"
     mode: '644'
     headers: "{{ download_header }}"
-      # X-JFrog-Art-Api: "{{ artifactory_token }}"
   register: iim_zip
   when: download_url is defined
-
-# - name: Download IIM installer
-#   get_url:
-#     dest: "{{ tmp_dir.path }}/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
-#     url: "{{ artifactory_url }}/{{ artifactory_repo }}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
-#     mode: '644'
-#     headers:
-#       X-JFrog-Art-Api: "{{ artifactory_token }}"
-#   register: iim_zip
-#   when: download_url is defined
 
 - name: Extract IIM installer
   unarchive:

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -13,11 +13,11 @@
     dest: "{{tmp_dir.path}}/iim_installer.tar.gz"
   register: iim_zip
   when: download_url is not defined
-  
+
 - name: Download IIM installer
   get_url:
     dest: "{{ tmp_dir.path }}/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
-    # url: "{{ download_url }}/{{ artifactory_repo }}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
+    # url: "{{ artifactory_url }}/{{ artifactory_repo }}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
     url: "{{ download_url }}/{{ iim_installer_path }}"
     mode: '644'
     headers:
@@ -25,8 +25,6 @@
       {{ download_header }}
   register: iim_zip
   when: download_url is defined
-
-
 
 # - name: Download IIM installer
 #   get_url:

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -10,18 +10,17 @@
 - name: Copy installer
   copy:
     src: "{{ iim_installer_path }}"
-    dest: "{{tmp_dir.path}}/iim_installer.tar.gz"
-  register: iim_zip
+    dest: "{{ tmp_dir.path }}/"
   when: download_url is not defined
-
-- name: Download IIM installer
-  get_url:
-    dest: "{{ tmp_dir.path }}/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
-    url: "{{ download_url }}/{{ iim_installer_path }}"
-    mode: '644'
-    headers: "{{ download_header }}"
   register: iim_zip
+
+- name: Download installer
+  get_url:
+    url: "{{ download_url }}/{{ iim_installer_path }}"
+    dest: "{{ tmp_dir.path }}/"
+    headers: "{{ download_header }}"
   when: download_url is defined
+  register: iim_zip
 
 - name: Extract IIM installer
   unarchive:

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -12,6 +12,31 @@
     src: "{{ iim_installer_path }}"
     dest: "{{tmp_dir.path}}/iim_installer.tar.gz"
   register: iim_zip
+  when: download_url is not defined
+  
+- name: Download IIM installer
+  get_url:
+    dest: "{{ tmp_dir.path }}/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
+    # url: "{{ download_url }}/{{ artifactory_repo }}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
+    url: "{{ download_url }}/{{ iim_installer_path }}"
+    mode: '644'
+    headers:
+      # X-JFrog-Art-Api: "{{ artifactory_token }}"
+      {{ download_header }}
+  register: iim_zip
+  when: download_url is defined
+
+
+
+# - name: Download IIM installer
+#   get_url:
+#     dest: "{{ tmp_dir.path }}/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
+#     url: "{{ artifactory_url }}/{{ artifactory_repo }}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"
+#     mode: '644'
+#     headers:
+#       X-JFrog-Art-Api: "{{ artifactory_token }}"
+#   register: iim_zip
+#   when: download_url is defined
 
 - name: Extract IIM installer
   unarchive:

--- a/roles/iim/tasks/windows.yml
+++ b/roles/iim/tasks/windows.yml
@@ -5,18 +5,25 @@
     state: directory
   register: tmp_dir
 
-
 - name: Copy installer
-  copy:
+  win_copy:
     src: "{{ iim_installer_path }}"
-    dest: "{{tmp_dir.path}}/iim_installer.tar.gz"
+    dest: "{{ tmp_dir.path }}/"
+  when: download_url is not defined
+  register: iim_zip
+
+- name: Download IIM installer
+  win_get_url:
+    url: "{{ download_url }}/{{ iim_installer_path }}"
+    dest: "{{ tmp_dir.path }}/"
+    headers: "{{ download_header }}"
+  when: download_url is defined
   register: iim_zip
 
 - name: Extract IIM installer
   win_unzip:
     src: "{{ iim_zip.dest }}"
     dest: "{{ tmp_dir.path }}"
-    remote_src: yes
     creates: "{{ tmp_dir.path }}/installc.exe"
 
 - name: Run IIM installer

--- a/roles/iim/vars/darwin.yml
+++ b/roles/iim/vars/darwin.yml
@@ -1,2 +1,4 @@
 ---
 iim_install_path: /Applications/IBM/InstallationManager
+# paths can be relative to download_url or local
+iim_installer_path: "IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"

--- a/roles/iim/vars/debian.yml
+++ b/roles/iim/vars/debian.yml
@@ -1,2 +1,4 @@
 ---
 iim_install_path: /opt/IBM/InstallationManager
+# paths can be relative to download_url or local
+iim_installer_path: "IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"

--- a/roles/iim/vars/redhat.yml
+++ b/roles/iim/vars/redhat.yml
@@ -1,4 +1,3 @@
 ---
 # url relative OR local
 iim_install_path: /opt/IBM/InstallationManager
-

--- a/roles/iim/vars/redhat.yml
+++ b/roles/iim/vars/redhat.yml
@@ -1,5 +1,4 @@
 ---
-# url relative OR local
 iim_install_path: /opt/IBM/InstallationManager
 # paths can be relative to download_url or local
 iim_installer_path: "IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"

--- a/roles/iim/vars/redhat.yml
+++ b/roles/iim/vars/redhat.yml
@@ -1,2 +1,4 @@
 ---
+# url relative OR local
 iim_install_path: /opt/IBM/InstallationManager
+

--- a/roles/iim/vars/redhat.yml
+++ b/roles/iim/vars/redhat.yml
@@ -1,3 +1,5 @@
 ---
 # url relative OR local
 iim_install_path: /opt/IBM/InstallationManager
+# paths can be relative to download_url or local
+iim_installer_path: "IIM/agent.installer.linux.gtk.x86_64_{{ iim_agent_version }}.zip"

--- a/roles/iim/vars/windows.yml
+++ b/roles/iim/vars/windows.yml
@@ -1,2 +1,4 @@
 ---
 iim_install_path: C:/IBM/InstallationManager
+# paths can be relative to download_url or local
+iim_installer_path: "IIM/agent.installer.win32.win32.x86_64_{{ iim_agent_version }}.zip"

--- a/scripts/downloadInstaller.sh
+++ b/scripts/downloadInstaller.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo service is $1
 
-elif [ "$1" = "ihs-v90-centos-8" ]; then
+if [ "$1" = "ihs-v90-centos-8" ]; then
   echo "Download IHS installer and fixpacks"
   mkdir -p /tmp/repo-zips/
   curl -H "X-JFrog-Art-Api: ${ARTIFACTORY_TOKEN}" -k ${ARTIFACTORY_URL}/${ARTIFACTORY_REPO}/SoftwareInstallers/WAS/9.0.5ND/was.repo.90500.ihs.zip -o /tmp/repo-zips/was.repo.90500.ihs.zip
@@ -16,10 +16,6 @@ elif [ "$1" = "ihs-v90-centos-8" ]; then
 
 
 elif [ "$1" = "ihs-v80-centos-7" ]; then
-  echo "Download IIM installer"
-  mkdir -p /tmp/iim/
-  curl -H "X-JFrog-Art-Api: ${ARTIFACTORY_TOKEN}" -k ${ARTIFACTORY_URL}/${ARTIFACTORY_REPO}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_1.9.1001.20191112_1525.zip -o /tmp/iim/iim_installer.tar.gz
-
   echo "Download IHS installer and fixpacks"
   mkdir -p /tmp/repo-zips/
   curl -H "X-JFrog-Art-Api: ${ARTIFACTORY_TOKEN}" -k ${ARTIFACTORY_URL}/${ARTIFACTORY_REPO}/SoftwareInstallers/WAS/8.5.5ND/WAS_V8.5.5_SUPPL_1_OF_3.zip -o /tmp/repo-zips/WAS_V8.5.5_SUPPL_1_OF_3.zip

--- a/scripts/downloadInstaller.sh
+++ b/scripts/downloadInstaller.sh
@@ -1,27 +1,7 @@
 #!/bin/bash
 echo service is $1
-# IIM
-if [ "$1" = "iim-191-centos-8" ]; then
-  echo "Download IIM installer"
-  mkdir -p /tmp/iim/
-  curl -H "X-JFrog-Art-Api: ${ARTIFACTORY_TOKEN}" -k ${ARTIFACTORY_URL}/${ARTIFACTORY_REPO}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_1.9.1001.20191112_1525.zip -o /tmp/iim/iim_installer.tar.gz
-# Websphere
-elif [ "$1" = "websphere-v85-centos-7" ]; then
-  echo "Download IIM installer"
-  mkdir -p /tmp/iim/
-  curl -H "X-JFrog-Art-Api: ${ARTIFACTORY_TOKEN}" -k ${ARTIFACTORY_URL}/${ARTIFACTORY_REPO}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_1.9.1001.20191112_1525.zip -o /tmp/iim/iim_installer.tar.gz
-
-elif [ "$1" = "websphere-v90-centos-8" ]; then
-  echo "Download IIM installer"
-  mkdir -p /tmp/iim/
-  curl -H "X-JFrog-Art-Api: ${ARTIFACTORY_TOKEN}" -k ${ARTIFACTORY_URL}/${ARTIFACTORY_REPO}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_1.9.1001.20191112_1525.zip -o /tmp/iim/iim_installer.tar.gz
-
 
 elif [ "$1" = "ihs-v90-centos-8" ]; then
-  echo "Download IIM installer"
-  mkdir -p /tmp/iim/
-  curl -H "X-JFrog-Art-Api: ${ARTIFACTORY_TOKEN}" -k ${ARTIFACTORY_URL}/${ARTIFACTORY_REPO}/SoftwareInstallers/IIM/agent.installer.linux.gtk.x86_64_1.9.1001.20191112_1525.zip -o /tmp/iim/iim_installer.tar.gz
-
   echo "Download IHS installer and fixpacks"
   mkdir -p /tmp/repo-zips/
   curl -H "X-JFrog-Art-Api: ${ARTIFACTORY_TOKEN}" -k ${ARTIFACTORY_URL}/${ARTIFACTORY_REPO}/SoftwareInstallers/WAS/9.0.5ND/was.repo.90500.ihs.zip -o /tmp/repo-zips/was.repo.90500.ihs.zip


### PR DESCRIPTION
- [x] Update version in `galaxy.yml`
- Remove duplicate scenario from travis
- Add option to download iim installer zip from server
- Update molecule to use download option instead of messy copy script
- Update vars to work with both copy/download (by adding iim_installer_path)
- Add download_url to ihs molecule tests to use download
- Fix some obvious windows bugs e.g. copy instead of win_copy - should be tested in future

Replaces original PR: https://github.com/IBM/spm-middleware/pull/20