### PR TITLE
Fix copy task for IIM (do not merge)

### DIFF
--- a/roles/iim/defaults/main.yml
+++ b/roles/iim/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 iim_agent_version: 1.9.1001.20191112_1525
 # Server info for downloading installers / repos directly, leave blank to copy
-download_url:  # e.g. https://artifactory/repo
-download_header:  # e.g. X-JFrog-Art-Api: "{{ lookup('env', 'MYTOKEN') }}"
+# download_url:  # e.g. https://artifactory/repo
+# download_header:  # e.g. X-JFrog-Art-Api: "{{ lookup('env', 'MYTOKEN') }}"

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -12,7 +12,7 @@
     src: "{{ iim_installer_path }}"
     dest: "{{ tmp_dir.path }}/"
   when: download_url is not defined
-  register: iim_zip
+  # register: iim_zip
 
 - name: Download installer
   get_url:
@@ -20,11 +20,12 @@
     dest: "{{ tmp_dir.path }}/"
     headers: "{{ download_header }}"
   when: download_url is defined
-  register: iim_zip
+  # register: iim_zip
 
 - name: Extract IIM installer
   unarchive:
-    src: "{{ iim_zip.dest }}"
+    # src: "{{ iim_zip.dest }}"
+    src: "{{ tmp_dir.path }}"
     dest: "{{ tmp_dir.path }}"
     remote_src: yes
     mode: 0755

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -25,7 +25,7 @@
 - name: Extract IIM installer
   unarchive:
     # src: "{{ iim_zip.dest }}"
-    src: "{{ tmp_dir.path }}"
+    src: "{{ tmp_dir }}"
     dest: "{{ tmp_dir.path }}"
     remote_src: yes
     mode: 0755
@@ -40,6 +40,6 @@
 
 - name: Delete temporary directory
   file:
-    path: "{{ tmp_dir.path }}"
+    path: "{{ tmp_dir }}"
     state: absent
   become: yes

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -5,14 +5,12 @@
     recurse: yes
     mode: 0755
     state: directory
-  # register: tmp_dir
 
 - name: Copy installer
   copy:
     src: "{{ iim_installer_path }}"
     dest: /tmp/iim/iimInstaller.zip
   when: download_url is not defined
-  # register: iim_zip
 
 - name: Download installer
   get_url:
@@ -20,11 +18,9 @@
     dest: /tmp/iim/iimInstaller.zip
     headers: "{{ download_header }}"
   when: download_url is defined
-  # register: iim_zip
 
 - name: Extract IIM installer
   unarchive:
-    # src: "{{ iim_zip.dest }}"
     src: /tmp/iim/iimInstaller.zip
     dest: /tmp/iim/
     remote_src: yes

--- a/roles/iim/tasks/linux_common.yml
+++ b/roles/iim/tasks/linux_common.yml
@@ -5,19 +5,19 @@
     recurse: yes
     mode: 0755
     state: directory
-  register: tmp_dir
+  # register: tmp_dir
 
 - name: Copy installer
   copy:
     src: "{{ iim_installer_path }}"
-    dest: "{{ tmp_dir.path }}/"
+    dest: /tmp/iim/iimInstaller.zip
   when: download_url is not defined
   # register: iim_zip
 
 - name: Download installer
   get_url:
     url: "{{ download_url }}/{{ iim_installer_path }}"
-    dest: "{{ tmp_dir.path }}/"
+    dest: /tmp/iim/iimInstaller.zip
     headers: "{{ download_header }}"
   when: download_url is defined
   # register: iim_zip
@@ -25,21 +25,21 @@
 - name: Extract IIM installer
   unarchive:
     # src: "{{ iim_zip.dest }}"
-    src: "{{ tmp_dir }}"
-    dest: "{{ tmp_dir.path }}"
+    src: /tmp/iim/iimInstaller.zip
+    dest: /tmp/iim/
     remote_src: yes
     mode: 0755
-    creates: "{{ tmp_dir.path }}/installc"
+    creates: /tmp/iim/installc
 
 - name: Run IIM installer
   command:
     cmd: ./installc -acceptLicense -iD {{ iim_install_path }}
-    chdir: "{{ tmp_dir.path }}"
+    chdir: /tmp/iim/
     creates: "{{ iim_install_path }}"
   become: yes
 
 - name: Delete temporary directory
   file:
-    path: "{{ tmp_dir }}"
+    path: /tmp/iim/
     state: absent
   become: yes


### PR DESCRIPTION
Local installers copy path tested. Should apply the following to all roles:
- download_url section commented out (avoids the bug where donwload_url is always considered defined) but left in for clarity of use.
- Do not register the same var in the copy/download tasks as one overrides the other. In general for these roles it seems more simple and readable to use full file paths, which are often shorter than the var being registered!